### PR TITLE
Misc fixs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.c	diff=cpp
+*.h	diff=cpp

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 alarmpanel
 galaxybus.o
 *~
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ LIBEMAIL=
 endif
 
 alarmpanel: alarmpanel.c galaxybus.o galaxybus.h ../AXL/axl.o ../AXL/axl.h ../Dataformat/dataformat.o ../Dataformat/dataformat.h
-	cc -O -o alarmpanel alarmpanel.c galaxybus.o -I. -I../AXL -I ../Dataformat ../AXL/axl.o ../Dataformat/dataformat.o -lcurl -lexpat -pthread -lpopt ${LIBEMAIL}
+	cc -Wall -O -o alarmpanel alarmpanel.c galaxybus.o -I. -I../AXL -I ../Dataformat ../AXL/axl.o ../Dataformat/dataformat.o -lcurl -lexpat -pthread -lpopt ${LIBEMAIL}
 
 galaxybus.o: galaxybus.c
-	cc -O -c -o galaxybus.o galaxybus.c -I. -DLIB -pthread
+	cc -Wall -O -c -o galaxybus.o galaxybus.c -I. -DLIB -pthread
 
 clean:
 	rm -f *.o alarmpanel

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ alarmpanel: alarmpanel.c galaxybus.o galaxybus.h ../AXL/axl.o ../AXL/axl.h ../Da
 
 galaxybus.o: galaxybus.c
 	cc -O -c -o galaxybus.o galaxybus.c -I. -DLIB -pthread
+
+clean:
+	rm -f *.o alarmpanel

--- a/alarmpanel.c
+++ b/alarmpanel.c
@@ -2008,7 +2008,7 @@ keypad_update (keypad_t * k, char key)
 		      }
 		  }
 	      }
-	    snprintf (l2, 17, "ACTIVE %-10s", state_name[t]);
+	    snprintf (l2, 17, "ACTIVE %-9s", state_name[t]);
 	    return NULL;
 	  }
       for (t = 0; t < STATE_LATCHED; t++)

--- a/galaxybus.c
+++ b/galaxybus.c
@@ -21,6 +21,8 @@
        along with this program.  If not, see <http://www.gnu.org/licenses/>.
      */
 
+#define _GNU_SOURCE
+
 #include <stdio.h>
 #include <string.h>
 #include <popt.h>


### PR DESCRIPTION
Some small patches

The only controversial one is perhaps 

    Makefile: Compile with -Wall

I've always used -Wall and now also generally use -Wextra.

There is one fix related that one

    alarmpanel: Fix a compiler warning

Where you were trying to stuff 18 bytes into a 17 byte buffer.

I don't have anyway of actually testing any of this, but it at least compiles cleanly under Fedora 26 with GCC 7.1.1. Although adding -Wextra does show plenty of warnings and cppcheck[0] also shows various potential issues.

[0] - http://cppcheck.sourceforge.net/

Cheers,
Andrew