### PR TITLE
alarmpanel: Fix a potential memory leak

### DIFF
--- a/alarmpanel.c
+++ b/alarmpanel.c
@@ -1666,6 +1666,7 @@ dolog (group_t g, const char *type, const char *user, const char *port, const ch
   if (!l)
     {
       warn ("malloc");
+      free(msg);
       return NULL;
     }
   memset (l, 0, sizeof (*l));


### PR DESCRIPTION
cppcheck[0] showed the following warning in alarmpanel.c

    [alarmpanel.c:1669]: (error) Memory leak: msg

This is in dolog(), where msg is allocated via a call to vasprintf(3).
However a few lines down we may bail out this function before it gets
assigned to l->msg.

[0] - http://cppcheck.sourceforge.net/

Signed-off-by: Andrew Clayton <andrew@digital-domain.net>