### PR TITLE
Fix build using CMake.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,6 +50,3 @@
 	path = email
 	url = https://github.com/revk/email
 	branch = main
-[submodule "ESP32/components/esp-wolfssl"]
-	path = ESP32/components/esp-wolfssl
-	url = https://github.com/espressif/esp-wolfssl.git

--- a/ESP32/main/CMakeLists.txt
+++ b/ESP32/main/CMakeLists.txt
@@ -1,2 +1,3 @@
-set (COMPONENT_SRCS "SS.c" "door.c" "keypad.c" "nfc.c" "ranger.c" "input.c" "output.c")
-set (COMPONENT_REQUIRES "ESP32RevK") register_component ()
+set (COMPONENT_SRCS "SS.c" "door.c" "keypad.c" "nfc.c" "input.c" "output.c" "alarm.c")
+set (COMPONENT_REQUIRES "ESP32-RevK" "DESFireAES" "ESP32-PN532" "ESP32-GalaxyBus")
+register_component ()

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,12 @@ SQLLIB=$(shell mariadb_config --libs)
 SQLVER=$(shell mariadb_config --version | sed 'sx\..*xx')
 endif
 
+ifneq ("$(wildcard ESP32/build/config/sdkconfig.h)","")
+BUILD_ESP32_USING_CMAKE=-DBUILD_ESP32_USING_CMAKE
+else
+BUILD_ESP32_USING_CMAKE=
+endif
+
 ifndef KCONFIG_CONFIG
 KCONFIG_CONFIG=solarsystem.conf
 endif
@@ -100,7 +106,7 @@ ssafile.o: ssafile.c ssafile.h Makefile config.h
 	gcc -g -Wall -Wextra -O -c -o $@ $< ${SQLINC} -DLIB
 
 solarsystem: solarsystem.c config.h AXL/axl.o AJL/ajl.o Dataformat/dataformat.o DESFireAES/desfireaes.o SQLlib/sqllib.o Makefile ssdatabase.o ssmqtt.o sscert.o fobcommand.o mqttmsg.o ssafile.o
-	gcc -g -Wall -Wextra -O -o $@ $< ssdatabase.o ssmqtt.o sscert.o AJL/ajlcurl.o AXL/axl.o Dataformat/dataformat.o DESFireAES/desfireaes.o SQLlib/sqllib.o ${SQLINC} ${SQLLIB} -lpopt -lcrypto -pthread -lcurl -lssl fobcommand.o mqttmsg.o ssafile.o
+	gcc -g -Wall -Wextra -O ${BUILD_ESP32_USING_CMAKE} -o $@ $< ssdatabase.o ssmqtt.o sscert.o AJL/ajlcurl.o AXL/axl.o Dataformat/dataformat.o DESFireAES/desfireaes.o SQLlib/sqllib.o ${SQLINC} ${SQLLIB} -lpopt -lcrypto -pthread -lcurl -lssl fobcommand.o mqttmsg.o ssafile.o
 
 can: can.c config.h Makefile login/redirect.o
 	gcc -g -Wall -Wextra -O -o $@ $< SQLlib/sqllib.o ${SQLINC} ${SQLLIB} -lpopt -lcurl AJL/ajl.o login/redirect.o

--- a/solarsystem.c
+++ b/solarsystem.c
@@ -2,7 +2,11 @@
 
 #define _GNU_SOURCE             /* See feature_test_macros(7) */
 #include "config.h"
+#ifdef BUILD_ESP32_USING_CMAKE
+#include "ESP32/build/config/sdkconfig.h"
+#else
 #include "ESP32/build/include/sdkconfig.h"
+#endif
 #include "ESP32/main/areas.h"
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Part of a collection of updates to allow the ESP32 code to build via CMake. [3/3]

Drop unused esp-wolfssl.
Tweak to solarsystem.c to cater for the change in location of sdkconfig.h when built using CMake.
