### PR TITLE
Fix missing user environment variables

### DIFF
--- a/login.conf.defaults
+++ b/login.conf.defaults
@@ -6,5 +6,5 @@ CONFIG_ENV_USER_FIELD_LIST="username,admin"
 CONFIG_CGI_PATH="..:../login:../email:../xmlsql:../login/SQLlib:/usr/local/bin:/bin:/usr/bin:/usr/local/mysql/bin"
 CONFIG_FORM_SECURITY_POSTS=y
 CONFIG_BLOCK_GET=y
-CONFIG_ENV_FIELD_LIST=username,admin
+CONFIG_ENV_FIELD_LIST="username,admin,organisation,site"
 

--- a/login.conf.defaults
+++ b/login.conf.defaults
@@ -2,9 +2,8 @@
 CONFIG_DB_DATABASE="SS"
 CONFIG_DB_USERNAME_FIELD="email"
 CONFIG_DB_USER_ID_FIELD="user"
-CONFIG_ENV_USER_FIELD_LIST="username,admin"
+CONFIG_ENV_USER_FIELD_LIST="username,admin,organisation,site"
 CONFIG_CGI_PATH="..:../login:../email:../xmlsql:../login/SQLlib:/usr/local/bin:/bin:/usr/bin:/usr/local/mysql/bin"
 CONFIG_FORM_SECURITY_POSTS=y
 CONFIG_BLOCK_GET=y
-CONFIG_ENV_FIELD_LIST="username,admin,organisation,site"
 


### PR DESCRIPTION
UI is broken when using the default values from login.conf.default.
CONFIG_ENV_FIELD_LIST is missing organisation and site.