### PR TITLE
Add arm, strong-arm and disarm to the API.

### DIFF
--- a/ssdatabase.m
+++ b/ssdatabase.m
@@ -120,6 +120,9 @@ bool (canunlock);               // Can unlock doors
 bool (canviewlog);              // Can view logs
 bool (canapi);                  // Can access API
 bool (apiexpires);              // Can set fob expiries via API
+bool (apiarm);                  // Can arm sites via API
+bool (apistrong);               // Can strong arm sites via API
+bool (apidisarm);               // Can disarm sites via API
 
 table(organisation, 0);         // Customer (may be more than one site)
 text(organisationname, 0);

--- a/www/edituserorganisation.cgi
+++ b/www/edituserorganisation.cgi
@@ -24,6 +24,9 @@ if($?userorganisationname) then
 	if(! $?canviewlog) setenv canviewlog false
 	if(! $?canapi) setenv canapi false
 	if(! $?apiexpires) setenv apiexpires false
+	if(! $?apiarm) setenv apiarm false
+	if(! $?apistrong) setenv apistrong false
+	if(! $?apidisarm) setenv apidisarm false
 	if($?ADMINORGANISATION) setenv allow "$allow admin"
 	if($?CANEDITORGANISATION) setenv allow "$allow caneditorganisation"
 	if($?CANEDITACCESS) setenv allow "$allow caneditaccess"
@@ -39,7 +42,7 @@ if($?userorganisationname) then
 	if($?CANDISARM) setenv allow "$allow candisarm"
 	if($?CANUNLOCK) setenv allow "$allow canunlock"
 	if($?CANVIEWLOG) setenv allow "$allow canviewlog"
-	if($?CANAPI) setenv allow "$allow canapi apiexpires"
+	if($?CANAPI) setenv allow "$allow canapi apiexpires apiarm apistrong apidisarm"
 	sqlwrite -qon "$DB" userorganisation $allow
 endif
 if($?DELETE) then
@@ -115,6 +118,9 @@ xmlsql -C -d "$DB" head.html - foot.html << 'END'
 <if CANVIEWLOG><tr><td><input type=checkbox id=canviewlog name=canviewlog value=true></td><td><label for=canviewlog>Can view logs</label></td></tr></if>
 <if CANAPI><tr><td><input type=checkbox id=canapi name=canapi value=true></td><td><label for=canapi>Can access API</label></td></tr></if>
 <if CANAPI canapi=true><tr><td><input type=checkbox id=apiexpires name=apiexpires value=true></td><td><label for=apiexpires>Can API set fob expires</label></td></tr></if>
+<if CANAPI canapi=true><tr><td><input type=checkbox id=apiarm name=apiarm value=true></td><td><label for=apiarm>Can API arm</label></td></tr></if>
+<if CANAPI canapi=true><tr><td><input type=checkbox id=apistrong name=apistrong value=true></td><td><label for=apistrong>Can API strong-arm</label></td></tr></if>
+<if CANAPI canapi=true><tr><td><input type=checkbox id=apidisarm name=apidisarm value=true></td><td><label for=apidisarm>Can API disarm</label></td></tr></if>
 </table>
 <input type=submit value="Update">
 <input type=submit name=DELETE value="Delete"><input type=checkbox name=SURE>


### PR DESCRIPTION
This adds support for arming, strong-arming and disarming via the API.

Please do test it out in your dev environment with real devices as I've only been able to do limited testing with my setup.

Example API commands below:

curl -u user@domain -X POST -H "Content-Type: application/json" -d '{"command":"arm", "site":1, "areas":"A"}' https://access.me.uk/api.cgi/1

curl -u user@domain -X POST -H "Content-Type: application/json" -d '{"command":"strong", "site":1, "areas":"A"}' https://access.me.uk/api.cgi/1

curl -u user@domain -X POST -H "Content-Type: application/json" -d '{"command":"disarm", "site":1, "areas":"A"}' https://access.me.uk/api.cgi/1